### PR TITLE
Add functionality for extending GridPath

### DIFF
--- a/src/gridextension.rs
+++ b/src/gridextension.rs
@@ -1,0 +1,7 @@
+#[derive(Clone,Copy)]
+pub enum GridExtension {
+    Right,
+    Up,
+    Left,
+    Down
+}

--- a/src/gridgraph.rs
+++ b/src/gridgraph.rs
@@ -3,8 +3,6 @@ use petgraph::Undirected;
 use petgraph::graph::Graph;
 use petgraph::visit::NodeIndexable;
 
-use crate::gridpath::GridPath;
-
 /// # GridGraph struct
 ///
 /// A `GridGraph` is an n by m grid of vertices where each
@@ -259,33 +257,6 @@ impl GridGraph {
 
         //If none of the forbidden cases are satisfied then return false
         false
-    }
-
-    /// Check whether the Hamiltonian path problem over this gird
-    /// graph is prime given its start and end vertices, and if so,
-    /// return the GridPath solution to the problem
-    pub fn get_prime_solution(&self, v_coords: [usize; 2], w_coords: [usize; 2]) -> Option<GridPath> {
-        //Sanity check on the input parameters
-        if v_coords[0] >= self.n || v_coords[1] >= self.m ||
-           w_coords[0] >= self.n || w_coords[1] >= self.m {
-            panic!(
-                "Coordinates out of bounds: ({},{}), ({},{})",
-                v_coords[0], v_coords[1],
-                w_coords[0], w_coords[1]
-            )
-        }
-
-        //Check if (n, m) is a possible prime case, if so then check
-        //the primality conditions for that case
-        match [self.n, self.m] {
-            [2, 2] => None,
-            [2, 3] => None,
-            [3, 2] => None,
-            [3, 3] => None,
-            [4, 5] => None,
-            [5, 4] => None,
-            _      => None
-        }
     }
 }
 

--- a/src/gridproblem.rs
+++ b/src/gridproblem.rs
@@ -1,5 +1,6 @@
 use crate::gridgraph::GridGraph;
 use crate::gridpath::GridPath;
+use crate::gridextension::GridExtension;
 
 /// # GridProblem struct
 ///
@@ -13,6 +14,7 @@ use crate::gridpath::GridPath;
 /// to the specified end vertex.
 pub struct GridProblem {
     grid_graph: GridGraph,
+    extensions: Vec<GridExtension>,
     start_coords: [usize; 2],
     end_coords: [usize; 2]
 }
@@ -35,11 +37,15 @@ impl GridProblem {
         //Initialize a new grid graph
         let grid_graph: GridGraph = GridGraph::new(width, height);
 
+        //Initialize an empty vector of grid extensions
+        let grid_extensions: Vec<GridExtension> = Vec::new();
+
         //Initialize the grid problem
         GridProblem {
-            grid_graph,
-            start_coords,
-            end_coords
+            grid_graph: grid_graph,
+            extensions: grid_extensions,
+            start_coords: start_coords,
+            end_coords: end_coords
         }
     }
 
@@ -59,52 +65,180 @@ impl GridProblem {
             );
         }
 
+        //Initialize an empty vector of grid extensions
+        let grid_extensions: Vec<GridExtension> = Vec::new();
+
         //Initialize the grid problem
         GridProblem {
-            grid_graph,
-            start_coords,
-            end_coords
+            grid_graph: grid_graph,
+            extensions: grid_extensions,
+            start_coords: start_coords,
+            end_coords: end_coords
         }
+    }
+
+    /// Check if the grid problem is acceptable
+    pub fn is_acceptable(&self) -> bool {
+        let are_color_compatible: bool = self.grid_graph.are_color_compatible(self.start_coords, self.end_coords);
+        let is_forbidden: bool = self.grid_graph.is_forbidden(self.start_coords, self.end_coords);
+        if are_color_compatible && !is_forbidden {
+            return true;
+        }
+        return false;
+    }
+
+    /// Reconstruct the original GridGraph and restore the original
+    /// coordinates if the GridGraph was stripped during the solution
+    /// of the GridProblem.  Clear the GridProblem's list of extensions
+    /// in the process.
+    pub fn reconstruct(&mut self) {
+        //Check if any extensions exist, if not then exit early
+        if self.extensions.len() == 0_usize {
+            return;
+        }
+
+        //Initialize new GridGraph dimensions and new start and end
+        //coordinates
+        let mut new_width: usize = self.grid_graph.get_width();
+        let mut new_height: usize = self.grid_graph.get_height();
+        let mut new_start_coords: [usize; 2] = self.start_coords;
+        let mut new_end_coords: [usize; 2] = self.end_coords;
+
+        //Loop through the GridProblem's extensions and determine the
+        //new GridGraph dimensions as well as the new start and end
+        //coordinates
+        for extension in self.extensions.iter() {
+            match extension {
+                GridExtension::Right => new_width += 2_usize,
+                GridExtension::Up => new_height += 2_usize,
+                GridExtension::Left => {
+                    new_width += 2_usize;
+                    new_start_coords[0] += 2_usize;
+                    new_end_coords[0] += 2_usize;
+                },
+                GridExtension::Down => {
+                    new_height += 2_usize;
+                    new_start_coords[1] += 2_usize;
+                    new_end_coords[1] += 2_usize;
+                }
+            }
+        }
+
+        //Initialize a new GridGraph using the new dimensions and update it
+        let new_grid_graph: GridGraph = GridGraph::new(new_width, new_height);
+        self.grid_graph = new_grid_graph;
+
+        //Update the start and end coords using the new coords
+        self.start_coords = new_start_coords;
+        self.end_coords = new_end_coords;
+
+        //Clear the extensions
+        self.extensions.clear();
     }
 
     /// Solve the grid problem by stripping and splitting it
     /// into sub-problems
-    pub fn solve(&self) -> Option<GridPath> {
-        //Check if the problem is acceptable
-        let are_color_compatible: bool = self.grid_graph.are_color_compatible(self.start_coords, self.end_coords);
-        let is_forbidden: bool = self.grid_graph.is_forbidden(self.start_coords, self.end_coords);
-        if !are_color_compatible || is_forbidden {
-            //If the problem is not acceptable, then there is no solution
+    pub fn solve(&mut self) -> Option<GridPath> {
+        //If the problem is not acceptable, then there is no solution
+        if !self.is_acceptable() {
             return None;
         }
 
-        //Get the width and height of the grid graph
-        let width: usize = self.grid_graph.get_width();
-        let height: usize = self.grid_graph.get_height();
-
-        //Check if either of the dimensions of the grid graph is 1
-        if width == 1 || height == 1 {
-            //Return the obvious path between the start and end vertices
-            let is_width: bool = width == 1;
-            let path: Vec<[usize; 2]> = {
-                let mut path_vec: Vec<[usize; 2]> = Vec::new();
-                let bound: usize = if is_width { height } else { width };
-                for i in 0..bound {
-                    let vertex_coords: [usize; 2] = if is_width { [0, i] } else { [i, 0] };
-                    path_vec.push(vertex_coords);
-                }
-                path_vec
+        //Initialize mutable grid graph, solution path, & collection of extensions
+        let mut solution: Option<GridPath> = None;
+        
+        //Loop until solved
+        loop {
+            //Check if there is a solution path
+            let is_solution: bool = match solution {
+                Some(ref _x) => true,
+                None => false
             };
-            return Some(GridPath::new(width, height, path));
-        }
 
-        //Check if this is a prime problem, if so then return it
-        if GridPath::is_prime(width, height, self.start_coords, self.end_coords) {
-            return GridPath::get_prime(width, height, self.start_coords, self.end_coords);
-        }
+            //If there is a solution path then extend it as needed and return it
+            if is_solution {
+                //Unwrap the solution path and extend it if any strips were performed
+                let mut solution_path: GridPath = solution.unwrap();
+                solution_path.extend_many(&self.extensions);
 
-        //TODO: Strip and split non prime paths until all are prime
-        //then solve and reconstruct
-        return None;
+                //Reconstruct the original GridProblem after having stripped it
+                self.reconstruct();
+                return Some(solution_path);
+            }
+
+            //If there is no solution path then break down the problem
+            //TODO: This implies the need for a GridProblem function "can_be_stripped"
+            //which assesses whether the grid problem can be stripped in any direction
+            //while self.can_be_stripped() {
+                //TODO: This implies the need for a GridProblem function "strip" which
+                //strips the GridProblem in some direction, following the same order as
+                //the aforementioned "can_be_stripped" function.
+            //    self.strip();
+            //}
+
+            //If the GridProblem can be split, then get its subproblems, solve them, and
+            //join their solutions into a solution path for the larger GridProblem.
+            //TODO: This implies the need for a GridProblem function "can_be_split_horizontally"
+            //which assesses whether the grid problem can be split along any horizontal edge.
+            //if self.can_be_split_horizontally() {
+                //TODO: This implies the need for a GridProblem function "split_horizontally"
+                //which takes a GridProblem and splits it, returning two smaller GridProblems
+                //which are the sub problems of the parent.
+            //    let (p_above, p_below): (GridProblem, GridProblem) = self.split_horizontally();
+            //    let p_above_solution: GridPath = p_above.solve().unwrap();
+            //    let p_below_solution: GridPath = p_below.solve().unwrap();
+                //TODO: This implies the need for a GridPath function "join_vertically" which
+                //accepts two GridPaths and joins them vertically at a shared vertex
+            //    let solution_path = GridPath.join_vertically(p_above_solution, p_below_solution);
+            //    solution = Some(solution_path);
+            //    continue;
+            //}
+
+            //TODO: This implies the need for a GridProblem function "can_be_split_vertically"
+            //which assesses whether the grid problem can be split along any vertical edge.
+            //if self.can_be_split_vertically() {
+                //TODO: This implies the need for a GridProblem function "split_vertically"
+                //which takes a GridProblem and splits it, returning two smaller GridProblems
+                //which are the sub problems of the parent.
+            //    let (p_left, p_right): (GridProblem, GridProblem) = self.split_vertically();
+            //    let p_left_solution: GridPath = p_left.solve().unwrap();
+            //    let p_right_solution: GridPath = p_right.solve().unwrap();
+                //TODO: This implies the need for a GridPath function "join_horizontally" which
+                //accepts two GridPaths and joins them horizontally at a shared vertex
+            //    let solution_path = GridPath.join_horizontally(p_left_solution, p_right_solution);
+            //    solution = Some(solution_path);
+            //    continue;
+            //}
+
+            //Get the width and height of the grid graph
+            let width: usize = self.grid_graph.get_width();
+            let height: usize = self.grid_graph.get_height();
+
+            //Check if either of the dimensions of the grid graph is 1, if so then solve it
+            //and set the solution path
+            if width == 1 || height == 1 {
+                let is_width: bool = width == 1;
+                let path: Vec<[usize; 2]> = {
+                    let mut path_vec: Vec<[usize; 2]> = Vec::new();
+                    let bound: usize = if is_width { height } else { width };
+                    for i in 0..bound {
+                        let vertex_coords: [usize; 2] = if is_width { [0, i] } else { [i, 0] };
+                        path_vec.push(vertex_coords);
+                    }
+                    path_vec
+                };
+                solution = Some(GridPath::new(width, height, path));
+                continue;
+            }
+
+            //Check if this is a prime problem, if so then solve it and set the solution path
+            if GridPath::is_prime(width, height, self.start_coords, self.end_coords) {
+                solution = GridPath::get_prime(width, height, self.start_coords, self.end_coords);
+                continue;
+            }
+
+            //This point should be unreachable, to avoid an infinite loop here we panic
+            panic!("Grid problem was acceptable but had no solution, could not be stripped, split, or solved.");
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,12 @@
 mod gridgraph;
 mod gridpath;
 mod gridproblem;
+mod gridextension;
 
 use crate::gridgraph::GridGraph;
 use crate::gridpath::GridPath;
 use crate::gridproblem::GridProblem;
+use crate::gridextension::GridExtension;
 
 fn main() {
     //Initialize a possibly prime grid graph and print it
@@ -13,13 +15,33 @@ fn main() {
     println!("{}", prime_grid_graph);
 
     //Initialize a prime grid problem from the grid graph
-    let prime_grid_problem: GridProblem = GridProblem::from_grid_graph(
+    let mut prime_grid_problem: GridProblem = GridProblem::from_grid_graph(
         prime_grid_graph,
         [1, 1], [0, 1]
     );
 
     //Solve the prime grid problem and print the solution
-    let prime_solution: GridPath = prime_grid_problem.solve().unwrap();
+    let mut prime_solution: GridPath = prime_grid_problem.solve().unwrap();
     println!("Solution");
+    println!("{}", prime_solution);
+
+    //Extend the prime grid solution to the right
+    prime_solution.extend(GridExtension::Right);
+    println!("Right-extended solution");
+    println!("{}", prime_solution);
+
+    //Extend the prime grid solution upward
+    prime_solution.extend(GridExtension::Up);
+    println!("Up-extended solution");
+    println!("{}", prime_solution);
+
+    //Extend the prime grid solution to the left
+    prime_solution.extend(GridExtension::Left);
+    println!("Left-extended solution");
+    println!("{}", prime_solution);
+
+    //Extend the prime grid solution downward
+    prime_solution.extend(GridExtension::Down);
+    println!("Down-extended solution");
     println!("{}", prime_solution);
 }


### PR DESCRIPTION
In this PR, I add the ability to extend a `GridPath` in any direction as long as it has an edge on the boundary in that direction.  This is driven by the enum `GridExtension` which specifies the directions in which a `GridPath` can be extended.